### PR TITLE
Make .cs highlighting legible on dark themes.

### DIFF
--- a/web_src/less/chroma/dark.less
+++ b/web_src/less/chroma/dark.less
@@ -52,7 +52,7 @@
 .chroma .ch { color: #6a737d; } /* CommentHashbang */
 .chroma .cm { color: #6a737d; } /* CommentMultiline */
 .chroma .c1 { color: #6a737d; } /* CommentSingle */
-.chroma .cs { color: #637d; } /* CommentSpecial */
+.chroma .cs { color: #95ad; } /* CommentSpecial */
 .chroma .cp { color: #fc6; } /* CommentPreproc */
 .chroma .cpf { color: #03dfff; } /* CommentPreprocFile */
 .chroma .gd { color: #fff; background-color: #5f3737; } /* GenericDeleted */


### PR DESCRIPTION
Fixes #19602.

Before:
![image](https://user-images.githubusercontent.com/96976531/166642315-d0c2e627-4011-44eb-b242-be4c66834f28.png)

After:
![image](https://user-images.githubusercontent.com/96976531/166642354-584c2ee7-34b9-4a00-bdf7-484b68087ee4.png)


NOTE:

I'm not presently able to build Gitea from source, so I have demo'd this style change by editing `theme-arc-greeen.css` in devtools. I hope this is acceptable given the scope of the PR.
